### PR TITLE
ci: use run_install instead of with_install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: pnpm/action-setup@f2b2b233b538f500472c7274c7012f57857d8ce0
         with:
-          with_install: false
+          run_install: false
       - uses: actions/setup-node@d7a11313b581b306c961b506cfc8971208bb03f6
         with:
           node-version: 24
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: pnpm/action-setup@f2b2b233b538f500472c7274c7012f57857d8ce0
         with:
-          with_install: false
+          run_install: false
       - uses: actions/setup-node@d7a11313b581b306c961b506cfc8971208bb03f6
         with:
           node-version: 24

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: pnpm/action-setup@f2b2b233b538f500472c7274c7012f57857d8ce0
         with:
-          with_install: false
+          run_install: false
       - uses: actions/setup-node@d7a11313b581b306c961b506cfc8971208bb03f6
         with:
           node-version: 24
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: pnpm/action-setup@f2b2b233b538f500472c7274c7012f57857d8ce0
         with:
-          with_install: false
+          run_install: false
       - uses: actions/setup-node@d7a11313b581b306c961b506cfc8971208bb03f6
         with:
           node-version: 24


### PR DESCRIPTION
The 'with_install' option in the pnpm/action-setup GitHub Action was incorrect