### PR TITLE
chore: migrate from npm to pnpm in IDX environment

### DIFF
--- a/.idx/dev.nix
+++ b/.idx/dev.nix
@@ -2,10 +2,11 @@
 # see: https://developers.google.com/idx/guides/customize-idx-env
 { pkgs, ... }: {
   # Which nixpkgs channel to use.
-  channel = "stable-24.11"; # or "unstable"
+  channel = "stable-25.05"; # or "unstable"
   # Use https://search.nixos.org/packages to find packages
   packages = [
     pkgs.nodejs_20
+    pkgs.pnpm
   ];
   # Sets environment variables in the workspace
   env = {};
@@ -17,7 +18,7 @@
     workspace = {
       # Runs when a workspace is first created with this `dev.nix` file
       onCreate = {
-        npm-install = "npm ci --no-audit --prefer-offline --no-progress --timing || npm i --no-audit --no-progress --timing";
+        npm-install = "pnpm install --frozen-lockfile";
         # Open editors for the following files by default, if they exist:
         default.openFiles = [ "src/app/app.component.ts" ];
       };
@@ -28,7 +29,7 @@
       enable = true;
       previews = {
         web = {
-          command = ["npm" "run" "start" "--" "--port" "$PORT" "--host" "0.0.0.0"];
+          command = ["pnpm" "run" "start" "--port" "$PORT" "--host" "0.0.0.0"];
           manager = "web";
         };
       };


### PR DESCRIPTION
This commit updates the `.idx/dev.nix` configuration to use `pnpm` instead of `npm` for dependency installation and running the development server.

The following changes are included:

- Added `pnpm` to the list of Nix packages.

- Updated the `onCreate` script to use `pnpm install`.

- Updated the `web` preview command to use `pnpm run start`.